### PR TITLE
Remove redundant display init call

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4,7 +4,6 @@
 
 extern "C" void app_main(void)
 {
-    display_init();
     ui::init();
 
     while (true) {


### PR DESCRIPTION
## Summary
- remove duplicate call to `display_init()` in `main.cpp`

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870ca0235708323b4f26fb81fe372b3