### PR TITLE
Add board choice via Kconfig

### DIFF
--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -1,0 +1,20 @@
+menu "Board Selection"
+
+choice
+    prompt "Target board"
+    default BOARD_7INCH
+
+config BOARD_7INCH
+    bool "Waveshare ESP32-S3 7 inch"
+
+config BOARD_7INCH_TYPEB
+    bool "Waveshare ESP32-S3 7 inch Type B"
+
+config BOARD_5INCH
+    bool "Waveshare ESP32-S3 5 inch"
+
+config BOARD_3_5INCH
+    bool "Waveshare ESP32-S3 3.5 inch"
+endchoice
+
+endmenu

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ idf.py build flash monitor
 
 ## Sélection de la carte
 
-Dans `main/board_config.hpp` décommente la ligne de ta carte :
-- BOARD_7INCH
-- BOARD_7INCH_TYPEB
-- BOARD_5INCH
-- BOARD_3_5INCH
+Lance `idf.py menuconfig` puis choisis **Board Selection** pour sélectionner ta carte :
+- Waveshare ESP32-S3 7 inch
+- Waveshare ESP32-S3 7 inch Type B
+- Waveshare ESP32-S3 5 inch
+- Waveshare ESP32-S3 3.5 inch
 
-Toutes les sources C et C++ incluent `board_config.hpp` pour récupérer
-les définitions de brochage correspondant à la carte sélectionnée.
+Toutes les sources C et C++ incluent `board_config.hpp` pour récupérer les
+définitions de brochage correspondant à la carte sélectionnée.
 
 ## Licence
 

--- a/README_en.md
+++ b/README_en.md
@@ -22,11 +22,11 @@ idf.py build flash monitor
 
 ## Selecting the board
 
-In `main/board_config.hpp` uncomment your board line:
-- BOARD_7INCH
-- BOARD_7INCH_TYPEB
-- BOARD_5INCH
-- BOARD_3_5INCH
+Run `idf.py menuconfig` and choose **Board Selection** to pick your board:
+- Waveshare ESP32-S3 7 inch
+- Waveshare ESP32-S3 7 inch Type B
+- Waveshare ESP32-S3 5 inch
+- Waveshare ESP32-S3 3.5 inch
 
 All C and C++ sources include `board_config.hpp` to obtain the pin definitions for the selected board.
 

--- a/main/board_config.hpp
+++ b/main/board_config.hpp
@@ -1,18 +1,15 @@
 #pragma once
-// Décommente la ligne correspondant à ta carte
-#define BOARD_7INCH
-// #define BOARD_7INCH_TYPEB
-// #define BOARD_5INCH
-// #define BOARD_3_5INCH
+// La sélection de la carte se fait dans `idf.py menuconfig` via les options
+// CONFIG_BOARD_*. Aucune modification manuelle de ce fichier n'est nécessaire.
 
-#if defined(BOARD_7INCH)
+#if defined(CONFIG_BOARD_7INCH)
 #include "board/board_7inch.hpp"
-#elif defined(BOARD_7INCH_TYPEB)
+#elif defined(CONFIG_BOARD_7INCH_TYPEB)
 #include "board/board_7inch_typeb.hpp"
-#elif defined(BOARD_5INCH)
+#elif defined(CONFIG_BOARD_5INCH)
 #include "board/board_5inch.hpp"
-#elif defined(BOARD_3_5INCH)
+#elif defined(CONFIG_BOARD_3_5INCH)
 #include "board/board_3_5inch.hpp"
 #else
-#error "Aucune carte définie ! Définissez BOARD_xxx dans board_config.hpp"
+#error "Aucune carte sélectionnée ! Configurez CONFIG_BOARD_xxx dans menuconfig"
 #endif


### PR DESCRIPTION
## Summary
- add `Kconfig.projbuild` with board selection options
- switch `board_config.hpp` to rely on `CONFIG_BOARD_*` values
- document configuration step using `idf.py menuconfig`

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file)*

------
https://chatgpt.com/codex/tasks/task_e_6870d59a78248323abad9db499f97243